### PR TITLE
added __init__.py and manifest.json

### DIFF
--- a/bin/custom_components/mitsubishi/manifest.json
+++ b/bin/custom_components/mitsubishi/manifest.json
@@ -1,0 +1,8 @@
+{
+  "domain": "mitsubishi",
+  "name": "Mitsubishi HVAC with Echonet lite",
+  "documentation": "https://github.com/scottyphillips/mitsubishi_echonet",
+  "dependencies": [],
+  "codeowners": [],
+  "requirements": []
+}


### PR DESCRIPTION
Due to [this](https://developers.home-assistant.io/blog/2019/04/12/new-integration-structure.html), you need to create empty file __init__.py and manifest.json in the folder custom_components/{your_platform} with custom_components. My Home Assistant stopped working in 0.92.1. I just added the minimal info. Please let me know if I can change something.