### PR TITLE
HA requires 'dry' for hvac mode.

### DIFF
--- a/bin/HA_0.96+/custom_components/mitsubishi/climate.py
+++ b/bin/HA_0.96+/custom_components/mitsubishi/climate.py
@@ -113,7 +113,7 @@ class MitsubishiClimate(ClimateDevice):
             self._fan_modes = fan_modes
         else:
             self._fan_modes = ['low', 'medium-high']
-        self._hvac_modes = ['heat', 'cool', 'fan_only', 'auto', 'off']
+        self._hvac_modes = ['heat', 'cool', 'dry', 'fan_only', 'auto', 'off']
         self._swing_list = ['auto', '1', '2', '3', 'off']
 
     def update(self):

--- a/bin/HA_pre_0.96/custom_components/mitsubishi/climate.py
+++ b/bin/HA_pre_0.96/custom_components/mitsubishi/climate.py
@@ -134,7 +134,7 @@ class MitsubishiClimate(ClimateDevice):
             self._fan_list = fan_list
         else:
             self._fan_list = ['low', 'medium-high']
-        self._operation_list = ['heat', 'cool', 'fan_only', 'auto', 'off']
+        self._operation_list = ['heat', 'cool', 'dry', 'fan_only', 'auto', 'off']
         self._swing_list = ['auto', '1', '2', '3', 'off']
 
         # self._target_temperature_high = target_temp_high

--- a/mitsubishi_echonet/esv.py
+++ b/mitsubishi_echonet/esv.py
@@ -22,7 +22,7 @@ MODES = {
 	'auto':  	0x41,
 	'cool':  	0x42,
 	'heat':  	0x43,
-	'dehumidify': 0x44,
+	'dry':          0x44,
 	'fan_only':	0x45,
 	'other': 	0x40
 }

--- a/mitsubishi_echonet/functions.py
+++ b/mitsubishi_echonet/functions.py
@@ -98,7 +98,7 @@ class Function:
            0x41: 'auto',
            0x42: 'cool',
            0x43: 'heat',
-           0x44: 'dehumidify',
+           0x44: 'dry',
            0x45: 'fan_only',
            0x40: 'other'
         }


### PR DESCRIPTION
Hi,

Thanks very much for this component, we have 5 heat pumps all hooked up working good. One of them is in a room we tend to use for drying clothes, so I've added the 'dry' mode. Just some minor tweaking as 'dehumidify' not a valid hvac mode for HA.  I though about making it configurable, but thought the heatpumps we are all using for this likely all support 'dry' mode.

Thanks again,,

Alex