### PR TITLE
hvac_action property required to show when unit is operational

### DIFF
--- a/bin/HA_0.96+/custom_components/mitsubishi/climate.py
+++ b/bin/HA_0.96+/custom_components/mitsubishi/climate.py
@@ -27,7 +27,12 @@ from homeassistant.components.climate import ClimateDevice
 from homeassistant.components.climate.const import (
     ATTR_TARGET_TEMP_HIGH, ATTR_TARGET_TEMP_LOW,
     SUPPORT_TARGET_TEMPERATURE, SUPPORT_TARGET_HUMIDITY,
-    SUPPORT_FAN_MODE, ATTR_FAN_MODES)
+    SUPPORT_FAN_MODE, ATTR_FAN_MODES,
+    CURRENT_HVAC_OFF, CURRENT_HVAC_HEAT, CURRENT_HVAC_COOL, 
+    CURRENT_HVAC_DRY, CURRENT_HVAC_IDLE, CURRENT_HVAC_FAN,
+    HVAC_MODE_OFF, HVAC_MODE_HEAT, HVAC_MODE_COOL,
+    HVAC_MODE_HEAT_COOL, HVAC_MODE_AUTO, HVAC_MODE_DRY,
+    HVAC_MODE_FAN_ONLY)
 from homeassistant.const import TEMP_CELSIUS, TEMP_FAHRENHEIT, ATTR_TEMPERATURE, CONF_HOST, CONF_IP_ADDRESS, CONF_NAME
 
 DOMAIN = "mitsubishi"
@@ -37,8 +42,8 @@ SUPPORT_FLAGS = 0
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
 
-    import mitsubishi_echonet as mit
-    # import custom_components.mitsubishi_echonet as mit
+    #import mitsubishi_echonet as mit
+    import custom_components.mitsubishi_echonet as mit
 
     """Set up the Mitsubishi ECHONET climate devices."""
     entities = []
@@ -113,7 +118,7 @@ class MitsubishiClimate(ClimateDevice):
             self._fan_modes = fan_modes
         else:
             self._fan_modes = ['low', 'medium-high']
-        self._hvac_modes = ['heat', 'cool', 'dry', 'fan_only', 'auto', 'off']
+        self._hvac_modes = ['heat', 'cool', 'dry','fan_only', 'auto', 'off']
         self._swing_list = ['auto', '1', '2', '3', 'off']
 
     def update(self):
@@ -183,6 +188,23 @@ class MitsubishiClimate(ClimateDevice):
     def hvac_mode(self):
         """Return current operation ie. heat, cool, idle."""
         return self._hvac_mode
+
+    @property
+    def hvac_action(self):
+        """Return current operation ie. heat, cool, idle."""
+        if self._hvac_mode == HVAC_MODE_HEAT:  
+           return CURRENT_HVAC_HEAT
+        if self._hvac_mode == HVAC_MODE_COOL:
+           return CURRENT_HVAC_COOL
+        if self._hvac_mode == HVAC_MODE_DRY:
+           return CURRENT_HVAC_DRY
+        if self._hvac_mode == HVAC_MODE_FAN_ONLY:
+           return CURRENT_HVAC_FAN
+        if self._hvac_mode == HVAC_MODE_AUTO:
+           """ TODO : distinguish auto activity"""
+           return CURRENT_HVAC_HEAT
+
+        return CURRENT_HVAC_OFF
 
     @property
     def hvac_modes(self):

--- a/bin/HA_0.96+/custom_components/mitsubishi/climate.py
+++ b/bin/HA_0.96+/custom_components/mitsubishi/climate.py
@@ -42,8 +42,8 @@ SUPPORT_FLAGS = 0
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
 
-    #import mitsubishi_echonet as mit
-    import custom_components.mitsubishi_echonet as mit
+    import mitsubishi_echonet as mit
+    #import custom_components.mitsubishi_echonet as mit
 
     """Set up the Mitsubishi ECHONET climate devices."""
     entities = []


### PR DESCRIPTION
Howdy, 

The climate refactor a few builds back means new property is required if you want the visual display of when the unit is (or has been) in use. I was missing the green fill so this PR re-adds it.

As far as I can tell we don't know what the unit is actually doing, only what mode it is in, i.e. we can't tell if it's idling or what action is it is in when in auto, so for the most part I've just taken the hvac mode as read - although there's a TODO in there for what to return when hvac mode is auto, for now just returning 'heating'.

Thanks,

Alex