### PR TITLE
Add convenience API for retrieving the Identification number of the node

### DIFF
--- a/mitsubishi_echonet/__init__.py
+++ b/mitsubishi_echonet/__init__.py
@@ -351,7 +351,6 @@ class EchoNetNode:
     def getOperationalStatus(self): # EPC 0x80
         return self.getMessage(0x80)
 
-
     """
     setOperationalStatus sets the ON/OFF state of the node
 
@@ -359,6 +358,14 @@ class EchoNetNode:
     """
     def setOperationalStatus(self, status): # EPC 0x80
         return self.setMessage(0x80, 0x30 if status else 0x31)
+
+    """
+    getIdentificationNumber returns a number used to identify an object uniquely
+
+    :return: Identification number as a string.
+    """
+    def getIdentificationNumber(self): # EPC 0x83
+        return self.getMessage(0x83)
 
     """
     On sets the node to ON.

--- a/mitsubishi_echonet/epc.py
+++ b/mitsubishi_echonet/epc.py
@@ -1323,7 +1323,7 @@ EPC_SUPER = {
 	0x80: ('Operation status', None),
 	0x81: ('Installation location', f._FF0081),
 	0x82: ('Standard version information', f._FF0082),
-	0x83: ('Identification number', None),
+	0x83: ('Identification number', f._FF0083),
 	0x84: ('Measured instantaneous power consumption', None),
 	0x85: ('Measured cumulative power consumption', None),
 	0x86: ('Manufacturers fault code', None),

--- a/mitsubishi_echonet/functions.py
+++ b/mitsubishi_echonet/functions.py
@@ -49,6 +49,14 @@ class Function:
         # ops_value = int.from_bytes(edt, 'little')
         return {'version_info': None}
 
+    # Get the identification number of the node
+    def _FF0083(edt):
+        if edt[0] == 0xFE:
+            ops_value = edt[1:].hex()
+        else:
+            ops_value = None
+        return {'identification_number': ops_value}
+
     # Check standard version information
     def _FF008A(edt):
         ops_value = int.from_bytes(edt, 'big')


### PR DESCRIPTION
I have been using your libraries for my own Daikin HVAC systems. Echonet is a standard, indeed!
Thank you for everything you have done. :)

I have added a simple API for retrieving the identification number of the node, by utilizing `EPC: 0x83`. This PR makes it possible, for instance, for the Home Assistant to give an EXACT `unique_id`.